### PR TITLE
Add proper support for imgLocat parameter

### DIFF
--- a/core/components/filedownloadr/models/filedownload/filedownload.class.php
+++ b/core/components/filedownloadr/models/filedownload/filedownload.class.php
@@ -32,6 +32,7 @@ class FileDownload {
         $corePath = $this->modx->getOption('core_path');
         $basePath = $corePath . 'components/filedownloadr/';
         $assetsUrl = $this->modx->getOption('assets_url') . 'components/filedownloadr/';
+        $configs['imgTypeUrl'] = !empty($configs['imgLocat']) ? $configs['imgLocat'] : $assetsUrl . 'img/filetypes/';
         $this->configs = array();
         $this->_output = array(
             'rows' => '',
@@ -47,7 +48,6 @@ class FileDownload {
             'chunksPath' => $basePath . 'elements/chunks/',
             'jsUrl' => $assetsUrl . 'js/',
             'cssUrl' => $assetsUrl . 'css/',
-            'imgTypeUrl' => $assetsUrl . 'img/filetypes/',
             'assetsUrl' => $assetsUrl,
             'encoding' => 'utf-8'
                 ), $configs);


### PR DESCRIPTION
imgLocat parameter was something that was being ignored as a parameter due to the call in $this->configs defining it.
